### PR TITLE
v1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,17 @@
 # hypixel-api
 
 [![ci](https://github.com/Sn0wo2/hypixel-api/actions/workflows/ci.yml/badge.svg)](https://github.com/Sn0wo2/hypixel-api/actions/workflows/ci.yml)
+[![lint](https://github.com/Sn0wo2/hypixel-api/actions/workflows/lint.yml/badge.svg)](https://github.com/Sn0wo2/hypixel-api/actions/workflows/lint.yml)
 [![CodeQL Advanced](https://github.com/Sn0wo2/hypixel-api/actions/workflows/codeql.yml/badge.svg)](https://github.com/Sn0wo2/hypixel-api/actions/workflows/codeql.yml)
 [![Dependabot Updates](https://github.com/Sn0wo2/hypixel-api/actions/workflows/dependabot/dependabot-updates/badge.svg)](https://github.com/Sn0wo2/hypixel-api/actions/workflows/dependabot/dependabot-updates)
-[![go-release](https://github.com/Sn0wo2/hypixel-api/actions/workflows/release.yml/badge.svg)](https://github.com/Sn0wo2/hypixel-api/actions/workflows/release.yml)
-[![lint](https://github.com/Sn0wo2/hypixel-api/actions/workflows/lint.yml/badge.svg)](https://github.com/Sn0wo2/hypixel-api/actions/workflows/lint.yml)
+[![Go Report Card](https://goreportcard.com/badge/github.com/Sn0wo2/hypixel-api)](https://goreportcard.com/report/github.com/Sn0wo2/hypixel-api)
+[![GitHub release](https://img.shields.io/github/v/release/Sn0wo2/hypixel-api?color=blue)](https://github.com/Sn0wo2/hypixel-api/releases)
+[![License](https://img.shields.io/badge/license-GPL3.0-green.svg)](LICENSE)
 
-A hypixel api wrapper in golang
+Hypixel API wrapper in Golang
+
+⚠️ [Hypixel API Policy](https://api.hypixel.net/#section/Introduction/Policies)
+
+## License
+ 
+[GPL-3.0](LICENSE)

--- a/api.go
+++ b/api.go
@@ -29,15 +29,15 @@ func (c *Client) Send(method string, head http.Header, path string, params *Para
 	if head != nil {
 		req.Header = head
 	}
-	if c.Rate != nil {
-		c.Rate.WaitIfNeeded()
+	if c.rate != nil {
+		c.rate.WaitIfNeeded()
 	}
-	rsp, err := c.HTTP.Do(req)
+	rsp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
-	if c.Rate != nil {
-		_ = c.Rate.UpdateFromHeaders(rsp.Header)
+	if c.rate != nil {
+		_ = c.rate.UpdateFromHeaders(rsp.Header)
 	}
 	return rsp, nil
 }
@@ -52,7 +52,7 @@ func (c *Client) Authentication(header ...http.Header) http.Header {
 	} else {
 		h = header[0]
 	}
-	h.Set("API-Key", c.APIKey)
+	h.Set("API-Key", c.apiKey)
 	return h
 }
 

--- a/api.go
+++ b/api.go
@@ -42,10 +42,10 @@ func (c *Client) Send(method string, head http.Header, path string, params *Para
 	return rsp, nil
 }
 
-// Authentication Add api key to header
+// AuthHeader Add api key to header
 //
 // https://api.hypixel.net/#section/Authentication/ApiKey
-func (c *Client) Authentication(header ...http.Header) http.Header {
+func (c *Client) AuthHeader(header ...http.Header) http.Header {
 	var h http.Header
 	if len(header) == 0 {
 		h = http.Header{}
@@ -61,7 +61,7 @@ func (c *Client) Authentication(header ...http.Header) http.Header {
 //
 // https://api.hypixel.net/#tag/Player-Data
 func (c *Client) GetPlayerData(uuid string) (*http.Response, error) {
-	return c.Send(http.MethodGet, c.Authentication(), "player", &Params{
+	return c.Send(http.MethodGet, c.AuthHeader(), "player", &Params{
 		"uuid": uuid,
 	})
 }
@@ -71,7 +71,7 @@ func (c *Client) GetPlayerData(uuid string) (*http.Response, error) {
 //
 // https://api.hypixel.net/#tag/Player-Data/paths/~1v2~1recentgames/get
 func (c *Client) GetRecentGames(uuid string) (*http.Response, error) {
-	return c.Send(http.MethodGet, c.Authentication(), "recentgames", &Params{
+	return c.Send(http.MethodGet, c.AuthHeader(), "recentgames", &Params{
 		"uuid": uuid,
 	})
 }
@@ -81,7 +81,7 @@ func (c *Client) GetRecentGames(uuid string) (*http.Response, error) {
 //
 // https://api.hypixel.net/#tag/Player-Data/paths/~1v2~1status/get
 func (c *Client) GetStatus(uuid string) (*http.Response, error) {
-	return c.Send(http.MethodGet, c.Authentication(), "status", &Params{
+	return c.Send(http.MethodGet, c.AuthHeader(), "status", &Params{
 		"uuid": uuid,
 	})
 }
@@ -91,7 +91,7 @@ func (c *Client) GetStatus(uuid string) (*http.Response, error) {
 //
 // https://api.hypixel.net/#tag/Player-Data/paths/~1v2~1guild/get
 func (c *Client) GetGuild(id, player, name string) (*http.Response, error) {
-	return c.Send(http.MethodGet, c.Authentication(), "guild", &Params{
+	return c.Send(http.MethodGet, c.AuthHeader(), "guild", &Params{
 		"id":     id,
 		"player": player,
 		"name":   name,
@@ -193,7 +193,7 @@ func (c *Client) GetSkyBlockCurrentBingoEvent() (*http.Response, error) {
 //
 // https://api.hypixel.net/#tag/SkyBlock/paths/~1v2~1resources~1skyblock~1news/get
 func (c *Client) GetSkyBlockNews() (*http.Response, error) {
-	return c.Send(http.MethodGet, c.Authentication(), "skyblock/news", nil)
+	return c.Send(http.MethodGet, c.AuthHeader(), "skyblock/news", nil)
 }
 
 // GetAuctions Request auction(s) by the auction UUID, player UUID, or profile UUID.
@@ -202,7 +202,7 @@ func (c *Client) GetSkyBlockNews() (*http.Response, error) {
 //
 // https://api.hypixel.net/#tag/SkyBlock/paths/~1v2~1skyblock~1auction/get
 func (c *Client) GetAuctions(uuid, player, profile string) (*http.Response, error) {
-	return c.Send(http.MethodGet, c.Authentication(), "skyblock/auction", &Params{
+	return c.Send(http.MethodGet, c.AuthHeader(), "skyblock/auction", &Params{
 		"uuid":    uuid,
 		"player":  player,
 		"profile": profile,
@@ -253,7 +253,7 @@ func (c *Client) GetBazaar() (*http.Response, error) {
 //
 // https://api.hypixel.net/#tag/SkyBlock/paths/~1v2~1skyblock~1profile/get
 func (c *Client) GetProfileByUUID(profile string) (*http.Response, error) {
-	return c.Send(http.MethodGet, c.Authentication(), "skyblock/profile", &Params{
+	return c.Send(http.MethodGet, c.AuthHeader(), "skyblock/profile", &Params{
 		"profile": profile,
 	})
 }
@@ -263,7 +263,7 @@ func (c *Client) GetProfileByUUID(profile string) (*http.Response, error) {
 //
 // https://api.hypixel.net/#tag/SkyBlock/paths/~1v2~1skyblock~1profiles/get
 func (c *Client) GetProfilesByPlayer(uuid string) (*http.Response, error) {
-	return c.Send(http.MethodGet, c.Authentication(), "skyblock/profiles", &Params{
+	return c.Send(http.MethodGet, c.AuthHeader(), "skyblock/profiles", &Params{
 		"uuid": uuid,
 	})
 }
@@ -274,7 +274,7 @@ func (c *Client) GetProfilesByPlayer(uuid string) (*http.Response, error) {
 //
 // https://api.hypixel.net/#tag/SkyBlock/paths/~1v2~1skyblock~1museum/get
 func (c *Client) GetMuseumData(profile string) (*http.Response, error) {
-	return c.Send(http.MethodGet, c.Authentication(), "skyblock/museum", &Params{
+	return c.Send(http.MethodGet, c.AuthHeader(), "skyblock/museum", &Params{
 		"profile": profile,
 	})
 }
@@ -285,7 +285,7 @@ func (c *Client) GetMuseumData(profile string) (*http.Response, error) {
 //
 // https://api.hypixel.net/#tag/SkyBlock/paths/~1v2~1skyblock~1garden/get
 func (c *Client) GetGardenData(profile string) (*http.Response, error) {
-	return c.Send(http.MethodGet, c.Authentication(), "skyblock/garden", &Params{
+	return c.Send(http.MethodGet, c.AuthHeader(), "skyblock/garden", &Params{
 		"profile": profile,
 	})
 }
@@ -296,7 +296,7 @@ func (c *Client) GetGardenData(profile string) (*http.Response, error) {
 //
 // https://api.hypixel.net/#tag/SkyBlock/paths/~1v2~1skyblock~1bingo/get
 func (c *Client) GetBingoData(uuid string) (*http.Response, error) {
-	return c.Send(http.MethodGet, c.Authentication(), "bingo", &Params{
+	return c.Send(http.MethodGet, c.AuthHeader(), "bingo", &Params{
 		"uuid": uuid,
 	})
 }
@@ -315,7 +315,7 @@ func (c *Client) GetActiveOrUpcomingFireSales() (*http.Response, error) {
 //
 // https://api.hypixel.net/#tag/Housing/paths/~1v2~1housing~1active/get
 func (c *Client) GetCurrentlyActivePublicHouses() (*http.Response, error) {
-	return c.Send(http.MethodGet, c.Authentication(), "housing/active", nil)
+	return c.Send(http.MethodGet, c.AuthHeader(), "housing/active", nil)
 }
 
 // GetSpecificHouseInformation Information about a specific house.
@@ -324,7 +324,7 @@ func (c *Client) GetCurrentlyActivePublicHouses() (*http.Response, error) {
 //
 // https://api.hypixel.net/#tag/Housing/paths/~1v2~1housing~1house/get
 func (c *Client) GetSpecificHouseInformation(house string) (*http.Response, error) {
-	return c.Send(http.MethodGet, c.Authentication(), "housing/house", &Params{
+	return c.Send(http.MethodGet, c.AuthHeader(), "housing/house", &Params{
 		"house": house,
 	})
 }
@@ -335,7 +335,7 @@ func (c *Client) GetSpecificHouseInformation(house string) (*http.Response, erro
 //
 // https://api.hypixel.net/#tag/Housing/paths/~1v2~1housing~1houses/get
 func (c *Client) GetSpecificPlayerPublicHouses(player string) (*http.Response, error) {
-	return c.Send(http.MethodGet, c.Authentication(), "housing/houses", &Params{
+	return c.Send(http.MethodGet, c.AuthHeader(), "housing/houses", &Params{
 		"player": player,
 	})
 }
@@ -345,7 +345,7 @@ func (c *Client) GetSpecificPlayerPublicHouses(player string) (*http.Response, e
 //
 // https://api.hypixel.net/#tag/Other/paths/~1v2~1boosters/get
 func (c *Client) GetActiveNetworkBoosters() (*http.Response, error) {
-	return c.Send(http.MethodGet, c.Authentication(), "boosters", nil)
+	return c.Send(http.MethodGet, c.AuthHeader(), "boosters", nil)
 }
 
 // GetCurrentPlayerCounts Current Player Counts
@@ -353,7 +353,7 @@ func (c *Client) GetActiveNetworkBoosters() (*http.Response, error) {
 //
 // https://api.hypixel.net/#tag/Other/paths/~1v2~1counts/get
 func (c *Client) GetCurrentPlayerCounts() (*http.Response, error) {
-	return c.Send(http.MethodGet, c.Authentication(), "counts", nil)
+	return c.Send(http.MethodGet, c.AuthHeader(), "counts", nil)
 }
 
 // GetCurrentLeaderboards Current Leaderboards
@@ -361,7 +361,7 @@ func (c *Client) GetCurrentPlayerCounts() (*http.Response, error) {
 //
 // https://api.hypixel.net/#tag/Other/paths/~1v2~1leaderboards/get
 func (c *Client) GetCurrentLeaderboards() (*http.Response, error) {
-	return c.Send(http.MethodGet, c.Authentication(), "leaderboards", nil)
+	return c.Send(http.MethodGet, c.AuthHeader(), "leaderboards", nil)
 }
 
 // GetPunishmentStatistics Punishment Statistics
@@ -369,5 +369,5 @@ func (c *Client) GetCurrentLeaderboards() (*http.Response, error) {
 //
 // https://api.hypixel.net/#tag/Other/paths/~1v2~1punishmentstats/get
 func (c *Client) GetPunishmentStatistics() (*http.Response, error) {
-	return c.Send(http.MethodGet, c.Authentication(), "punishmentstats", nil)
+	return c.Send(http.MethodGet, c.AuthHeader(), "punishmentstats", nil)
 }

--- a/api.go
+++ b/api.go
@@ -296,7 +296,7 @@ func (c *Client) GetGardenData(profile string) (*http.Response, error) {
 //
 // https://api.hypixel.net/#tag/SkyBlock/paths/~1v2~1skyblock~1bingo/get
 func (c *Client) GetBingoData(uuid string) (*http.Response, error) {
-	return c.Send(http.MethodGet, c.AuthHeader(), "bingo", &Params{
+	return c.Send(http.MethodGet, c.AuthHeader(), "skyblock/bingo", &Params{
 		"uuid": uuid,
 	})
 }

--- a/api.go
+++ b/api.go
@@ -57,6 +57,7 @@ func (c *Client) Authentication(header ...http.Header) http.Header {
 }
 
 // GetPlayerData Data of a specific player, including game stats
+// NEED API Key
 //
 // https://api.hypixel.net/#tag/Player-Data
 func (c *Client) GetPlayerData(uuid string) (*http.Response, error) {
@@ -66,6 +67,7 @@ func (c *Client) GetPlayerData(uuid string) (*http.Response, error) {
 }
 
 // GetRecentGames The recently played games of a specific player
+// NEED API Key
 //
 // https://api.hypixel.net/#tag/Player-Data/paths/~1v2~1recentgames/get
 func (c *Client) GetRecentGames(uuid string) (*http.Response, error) {
@@ -75,6 +77,7 @@ func (c *Client) GetRecentGames(uuid string) (*http.Response, error) {
 }
 
 // GetStatus The current online status of a specific player
+// NEED API Key
 //
 // https://api.hypixel.net/#tag/Player-Data/paths/~1v2~1status/get
 func (c *Client) GetStatus(uuid string) (*http.Response, error) {
@@ -84,6 +87,7 @@ func (c *Client) GetStatus(uuid string) (*http.Response, error) {
 }
 
 // GetGuild Retrieve a Guild by a player, id, or name
+// NEED API Key
 //
 // https://api.hypixel.net/#tag/Player-Data/paths/~1v2~1guild/get
 func (c *Client) GetGuild(id, player, name string) (*http.Response, error) {
@@ -185,6 +189,7 @@ func (c *Client) GetSkyBlockCurrentBingoEvent() (*http.Response, error) {
 }
 
 // GetSkyBlockNews News
+// NEED API Key
 //
 // https://api.hypixel.net/#tag/SkyBlock/paths/~1v2~1resources~1skyblock~1news/get
 func (c *Client) GetSkyBlockNews() (*http.Response, error) {
@@ -193,6 +198,7 @@ func (c *Client) GetSkyBlockNews() (*http.Response, error) {
 
 // GetAuctions Request auction(s) by the auction UUID, player UUID, or profile UUID.
 // Returns the auctions selected by the provided query. Only one query parameter can be used in a single request, and cannot be filtered by multiple.
+// NEED API Key
 //
 // https://api.hypixel.net/#tag/SkyBlock/paths/~1v2~1skyblock~1auction/get
 func (c *Client) GetAuctions(uuid, player, profile string) (*http.Response, error) {
@@ -243,6 +249,7 @@ func (c *Client) GetBazaar() (*http.Response, error) {
 
 // GetProfileByUUID Profile by UUID
 // SkyBlock profile data, such as stats, objectives etc. The data returned can differ depending on the players in-game API settings.
+// NEED API Key
 //
 // https://api.hypixel.net/#tag/SkyBlock/paths/~1v2~1skyblock~1profile/get
 func (c *Client) GetProfileByUUID(profile string) (*http.Response, error) {
@@ -252,6 +259,7 @@ func (c *Client) GetProfileByUUID(profile string) (*http.Response, error) {
 }
 
 // GetProfilesByPlayer Profiles by player
+// NEED API Key
 //
 // https://api.hypixel.net/#tag/SkyBlock/paths/~1v2~1skyblock~1profiles/get
 func (c *Client) GetProfilesByPlayer(uuid string) (*http.Response, error) {
@@ -262,6 +270,7 @@ func (c *Client) GetProfilesByPlayer(uuid string) (*http.Response, error) {
 
 // GetMuseumData Museum data by profile ID
 // SkyBlock museum data for all members of the provided profile. The data returned can differ depending on the players in-game API settings.
+// NEED API Key
 //
 // https://api.hypixel.net/#tag/SkyBlock/paths/~1v2~1skyblock~1museum/get
 func (c *Client) GetMuseumData(profile string) (*http.Response, error) {
@@ -272,6 +281,7 @@ func (c *Client) GetMuseumData(profile string) (*http.Response, error) {
 
 // GetGardenData Garden data by profile ID
 // SkyBlock garden data for the provided profile.
+// NEED API Key
 //
 // https://api.hypixel.net/#tag/SkyBlock/paths/~1v2~1skyblock~1garden/get
 func (c *Client) GetGardenData(profile string) (*http.Response, error) {
@@ -282,6 +292,7 @@ func (c *Client) GetGardenData(profile string) (*http.Response, error) {
 
 // GetBingoData Bingo data by player
 // Bingo data for participated events of the provided player.
+// NEED API Key
 //
 // https://api.hypixel.net/#tag/SkyBlock/paths/~1v2~1skyblock~1bingo/get
 func (c *Client) GetBingoData(uuid string) (*http.Response, error) {
@@ -300,6 +311,7 @@ func (c *Client) GetActiveOrUpcomingFireSales() (*http.Response, error) {
 
 // GetCurrentlyActivePublicHouses currently active public houses.
 // This data may be cached for a short period of time.
+// NEED API Key
 //
 // https://api.hypixel.net/#tag/Housing/paths/~1v2~1housing~1active/get
 func (c *Client) GetCurrentlyActivePublicHouses() (*http.Response, error) {
@@ -308,6 +320,7 @@ func (c *Client) GetCurrentlyActivePublicHouses() (*http.Response, error) {
 
 // GetSpecificHouseInformation Information about a specific house.
 // This data may be cached for a short period of time.
+// NEED API Key
 //
 // https://api.hypixel.net/#tag/Housing/paths/~1v2~1housing~1house/get
 func (c *Client) GetSpecificHouseInformation(house string) (*http.Response, error) {
@@ -318,6 +331,7 @@ func (c *Client) GetSpecificHouseInformation(house string) (*http.Response, erro
 
 // GetSpecificPlayerPublicHouses The public houses for a specific player.//
 // This data may be cached for a short period of time.
+// NEED API Key
 //
 // https://api.hypixel.net/#tag/Housing/paths/~1v2~1housing~1houses/get
 func (c *Client) GetSpecificPlayerPublicHouses(player string) (*http.Response, error) {
@@ -327,6 +341,7 @@ func (c *Client) GetSpecificPlayerPublicHouses(player string) (*http.Response, e
 }
 
 // GetActiveNetworkBoosters Active Network Boosters
+// NEED API Key
 //
 // https://api.hypixel.net/#tag/Other/paths/~1v2~1boosters/get
 func (c *Client) GetActiveNetworkBoosters() (*http.Response, error) {
@@ -334,6 +349,7 @@ func (c *Client) GetActiveNetworkBoosters() (*http.Response, error) {
 }
 
 // GetCurrentPlayerCounts Current Player Counts
+// NEED API Key
 //
 // https://api.hypixel.net/#tag/Other/paths/~1v2~1counts/get
 func (c *Client) GetCurrentPlayerCounts() (*http.Response, error) {
@@ -341,6 +357,7 @@ func (c *Client) GetCurrentPlayerCounts() (*http.Response, error) {
 }
 
 // GetCurrentLeaderboards Current Leaderboards
+// NEED API Key
 //
 // https://api.hypixel.net/#tag/Other/paths/~1v2~1leaderboards/get
 func (c *Client) GetCurrentLeaderboards() (*http.Response, error) {
@@ -348,6 +365,7 @@ func (c *Client) GetCurrentLeaderboards() (*http.Response, error) {
 }
 
 // GetPunishmentStatistics Punishment Statistics
+// NEED API Key
 //
 // https://api.hypixel.net/#tag/Other/paths/~1v2~1punishmentstats/get
 func (c *Client) GetPunishmentStatistics() (*http.Response, error) {

--- a/api.go
+++ b/api.go
@@ -7,7 +7,6 @@ import (
 )
 
 // Send Hypixel API HTTP Request
-// If you want bypass rate limit, use c.Rate.Reset()
 func (c *Client) Send(method string, head http.Header, path string, params *Params, payload ...byte) (*http.Response, error) {
 	if method == "" {
 		method = http.MethodGet
@@ -60,10 +59,6 @@ func (c *Client) Authentication(header ...http.Header) http.Header {
 // GetPlayerData Data of a specific player, including game stats
 //
 // https://api.hypixel.net/#tag/Player-Data
-// 200 Get player's data
-// 400 Some data is missing, this is usually a field.
-// 403 Access is forbidden, usually due to an invalid API key being used.
-// 429 A request limit has been reached, usually this is due to the limit on the key being reached but can also be triggered by a global throttle.
 func (c *Client) GetPlayerData(uuid string) (*http.Response, error) {
 	return c.Send(http.MethodGet, c.Authentication(), "player", &Params{
 		"uuid": uuid,
@@ -73,11 +68,6 @@ func (c *Client) GetPlayerData(uuid string) (*http.Response, error) {
 // GetRecentGames The recently played games of a specific player
 //
 // https://api.hypixel.net/#tag/Player-Data/paths/~1v2~1recentgames/get
-// 200 Get player's recent game
-// 400 Some data is missing, this is usually a field.
-// 403 Access is forbidden, usually due to an invalid API key being used.
-// 422 Some data provided is invalid.
-// 429 A request limit has been reached, usually this is due to the limit on the key being reached but can also be triggered by a global throttle.
 func (c *Client) GetRecentGames(uuid string) (*http.Response, error) {
 	return c.Send(http.MethodGet, c.Authentication(), "recentgames", &Params{
 		"uuid": uuid,
@@ -87,10 +77,6 @@ func (c *Client) GetRecentGames(uuid string) (*http.Response, error) {
 // GetStatus The current online status of a specific player
 //
 // https://api.hypixel.net/#tag/Player-Data/paths/~1v2~1status/get
-// 200 Get player status
-// 400 Some data is missing, this is usually a field.
-// 403 Access is forbidden, usually due to an invalid API key being used.
-// 429 A request limit has been reached, usually this is due to the limit on the key being reached but can also be triggered by a global throttle.
 func (c *Client) GetStatus(uuid string) (*http.Response, error) {
 	return c.Send(http.MethodGet, c.Authentication(), "status", &Params{
 		"uuid": uuid,
@@ -100,14 +86,270 @@ func (c *Client) GetStatus(uuid string) (*http.Response, error) {
 // GetGuild Retrieve a Guild by a player, id, or name
 //
 // https://api.hypixel.net/#tag/Player-Data/paths/~1v2~1guild/get
-// 200 Get guild information
-// 400 Some data is missing, this is usually a field.
-// 403 Access is forbidden, usually due to an invalid API key being used.
-// 429 A request limit has been reached, usually this is due to the limit on the key being reached but can also be triggered by a global throttle.
 func (c *Client) GetGuild(id, player, name string) (*http.Response, error) {
 	return c.Send(http.MethodGet, c.Authentication(), "guild", &Params{
 		"id":     id,
 		"player": player,
 		"name":   name,
 	})
+}
+
+// GetGamesInformation Game Information
+// Returns information about Hypixel Games. This endpoint is in early development and we are working to add more information when possible
+//
+// https://api.hypixel.net/#tag/Resources/paths/~1v2~1resources~1games/get
+func (c *Client) GetGamesInformation() (*http.Response, error) {
+	return c.Send(http.MethodGet, nil, "resources/games", nil)
+}
+
+// GetAchievements Achievements
+//
+// https://api.hypixel.net/#tag/Resources/paths/~1v2~1resources~1achievements/get
+func (c *Client) GetAchievements() (*http.Response, error) {
+	return c.Send(http.MethodGet, nil, "resources/achievements", nil)
+}
+
+// GetChallenges Challenges
+//
+// https://api.hypixel.net/#tag/Resources/paths/~1v2~1resources~1challenges/get
+func (c *Client) GetChallenges() (*http.Response, error) {
+	return c.Send(http.MethodGet, nil, "resources/challenges", nil)
+}
+
+// GetQuests Quests
+//
+// https://api.hypixel.net/#tag/Resources/paths/~1v2~1resources~1quests/get
+func (c *Client) GetQuests() (*http.Response, error) {
+	return c.Send(http.MethodGet, nil, "resources/quests", nil)
+}
+
+// GetGuildAchievements Guild Achievements
+//
+// https://api.hypixel.net/#tag/Resources/paths/~1v2~1resources~1guilds~1achievements/get
+func (c *Client) GetGuildAchievements() (*http.Response, error) {
+	return c.Send(http.MethodGet, nil, "resources/guilds/achievements", nil)
+}
+
+// GetVanityPets Vanity Pets
+//
+// https://api.hypixel.net/#tag/Resources/paths/~1v2~1resources~1vanity~1pets/get
+func (c *Client) GetVanityPets() (*http.Response, error) {
+	return c.Send(http.MethodGet, nil, "resources/vanity/pets", nil)
+}
+
+// GetVanityCompanions Vanity Companions
+//
+// https://api.hypixel.net/#tag/Resources/paths/~1v2~1resources~1vanity~1companions/get
+func (c *Client) GetVanityCompanions() (*http.Response, error) {
+	return c.Send(http.MethodGet, nil, "resources/vanity/companions", nil)
+}
+
+// GetSkyBlockCollections Collections
+// Information regarding Collections in the SkyBlock game.
+//
+// https://api.hypixel.net/#tag/SkyBlock/paths/~1v2~1resources~1skyblock~1collections/get
+func (c *Client) GetSkyBlockCollections() (*http.Response, error) {
+	return c.Send(http.MethodGet, nil, "resources/skyblock/collections", nil)
+}
+
+// GetSkyBlockSkills Skills
+// Information regarding skills in the SkyBlock game.
+//
+// https://api.hypixel.net/#tag/SkyBlock/paths/~1v2~1resources~1skyblock~1skills/get
+func (c *Client) GetSkyBlockSkills() (*http.Response, error) {
+	return c.Send(http.MethodGet, nil, "resources/skyblock/skills", nil)
+}
+
+// GetSkyBlockItems Items
+// Information regarding items in the SkyBlock game.
+//
+// https://api.hypixel.net/#tag/SkyBlock/paths/~1v2~1resources~1skyblock~1items/get
+func (c *Client) GetSkyBlockItems() (*http.Response, error) {
+	return c.Send(http.MethodGet, nil, "resources/skyblock/items", nil)
+}
+
+// GetSkyBlockElectionAndMayor Election and Mayor
+// Information regarding the current mayor and ongoing election in SkyBlock.
+//
+// https://api.hypixel.net/#tag/SkyBlock/paths/~1v2~1resources~1skyblock~1election/get
+func (c *Client) GetSkyBlockElectionAndMayor() (*http.Response, error) {
+	return c.Send(http.MethodGet, nil, "resources/skyblock/election", nil)
+}
+
+// GetSkyBlockCurrentBingoEvent Current Bingo Event
+// Information regarding the current bingo event and its goals.
+//
+// https://api.hypixel.net/#tag/SkyBlock/paths/~1v2~1resources~1skyblock~1bingo/get
+func (c *Client) GetSkyBlockCurrentBingoEvent() (*http.Response, error) {
+	return c.Send(http.MethodGet, nil, "resources/skyblock/bingo", nil)
+}
+
+// GetSkyBlockNews News
+//
+// https://api.hypixel.net/#tag/SkyBlock/paths/~1v2~1resources~1skyblock~1news/get
+func (c *Client) GetSkyBlockNews() (*http.Response, error) {
+	return c.Send(http.MethodGet, c.Authentication(), "skyblock/news", nil)
+}
+
+// GetAuctions Request auction(s) by the auction UUID, player UUID, or profile UUID.
+// Returns the auctions selected by the provided query. Only one query parameter can be used in a single request, and cannot be filtered by multiple.
+//
+// https://api.hypixel.net/#tag/SkyBlock/paths/~1v2~1skyblock~1auction/get
+func (c *Client) GetAuctions(uuid, player, profile string) (*http.Response, error) {
+	return c.Send(http.MethodGet, c.Authentication(), "skyblock/auction", &Params{
+		"uuid":    uuid,
+		"player":  player,
+		"profile": profile,
+	})
+}
+
+// GetActiveAuctions Active auctions
+// Returns the currently active auctions sorted by last updated first and paginated.
+//
+// https://api.hypixel.net/#tag/SkyBlock/paths/~1v2~1skyblock~1auctions/get
+func (c *Client) GetActiveAuctions(page uint) (*http.Response, error) {
+	return c.Send(http.MethodGet, nil, "skyblock/auctions", &Params{
+		"page": page,
+	})
+}
+
+// GetRecentlyEndedAuctions Recently ended auctions
+// SkyBlock auctions which ended in the last 60 seconds.
+//
+// https://api.hypixel.net/#tag/SkyBlock/paths/~1v2~1skyblock~1auctions_ended/get
+func (c *Client) GetRecentlyEndedAuctions() (*http.Response, error) {
+	return c.Send(http.MethodGet, nil, "skyblock/auctions_ended", nil)
+}
+
+// GetBazaar Bazaar
+// Returns the list of products along with their sell summary, buy summary and quick status.
+// Product Description
+// The returned product info has 3 main fields:
+//
+// buy_summary
+// sell_summary
+// quick_status
+// buy_summary and are the current top 30 orders for each transaction type (in-game example: Stock of Stonks).sell_summary
+//
+// quick_status is a computed summary of the live state of the product (used for advanced mode view in the bazaar):
+//
+// sellVolume and are the sum of item amounts in all orders.buyVolume
+// sellPrice and are the weighted average of the top 2% of orders by volume.buyPrice
+// movingWeek is the historic transacted volume from last 7d + live state.
+// sellOrders and are the count of active orders. buyOrders
+func (c *Client) GetBazaar() (*http.Response, error) {
+	return c.Send(http.MethodGet, nil, "skyblock/bazaar", nil)
+}
+
+// GetProfileByUUID Profile by UUID
+// SkyBlock profile data, such as stats, objectives etc. The data returned can differ depending on the players in-game API settings.
+//
+// https://api.hypixel.net/#tag/SkyBlock/paths/~1v2~1skyblock~1profile/get
+func (c *Client) GetProfileByUUID(profile string) (*http.Response, error) {
+	return c.Send(http.MethodGet, c.Authentication(), "skyblock/profile", &Params{
+		"profile": profile,
+	})
+}
+
+// GetProfilesByPlayer Profiles by player
+//
+// https://api.hypixel.net/#tag/SkyBlock/paths/~1v2~1skyblock~1profiles/get
+func (c *Client) GetProfilesByPlayer(uuid string) (*http.Response, error) {
+	return c.Send(http.MethodGet, c.Authentication(), "skyblock/profiles", &Params{
+		"uuid": uuid,
+	})
+}
+
+// GetMuseumData Museum data by profile ID
+// SkyBlock museum data for all members of the provided profile. The data returned can differ depending on the players in-game API settings.
+//
+// https://api.hypixel.net/#tag/SkyBlock/paths/~1v2~1skyblock~1museum/get
+func (c *Client) GetMuseumData(profile string) (*http.Response, error) {
+	return c.Send(http.MethodGet, c.Authentication(), "skyblock/museum", &Params{
+		"profile": profile,
+	})
+}
+
+// GetGardenData Garden data by profile ID
+// SkyBlock garden data for the provided profile.
+//
+// https://api.hypixel.net/#tag/SkyBlock/paths/~1v2~1skyblock~1garden/get
+func (c *Client) GetGardenData(profile string) (*http.Response, error) {
+	return c.Send(http.MethodGet, c.Authentication(), "skyblock/garden", &Params{
+		"profile": profile,
+	})
+}
+
+// GetBingoData Bingo data by player
+// Bingo data for participated events of the provided player.
+//
+// https://api.hypixel.net/#tag/SkyBlock/paths/~1v2~1skyblock~1bingo/get
+func (c *Client) GetBingoData(uuid string) (*http.Response, error) {
+	return c.Send(http.MethodGet, c.Authentication(), "bingo", &Params{
+		"uuid": uuid,
+	})
+}
+
+// GetActiveOrUpcomingFireSales Active/Upcoming Fire Sales
+// Retrieve the currently active or upcoming Fire Sales for SkyBlock.
+//
+// https://api.hypixel.net/#tag/SkyBlock/paths/~1v2~1skyblock~1firesales/get
+func (c *Client) GetActiveOrUpcomingFireSales() (*http.Response, error) {
+	return c.Send(http.MethodGet, nil, "skyblock/firesales", nil)
+}
+
+// GetCurrentlyActivePublicHouses currently active public houses.
+// This data may be cached for a short period of time.
+//
+// https://api.hypixel.net/#tag/Housing/paths/~1v2~1housing~1active/get
+func (c *Client) GetCurrentlyActivePublicHouses() (*http.Response, error) {
+	return c.Send(http.MethodGet, c.Authentication(), "housing/active", nil)
+}
+
+// GetSpecificHouseInformation Information about a specific house.
+// This data may be cached for a short period of time.
+//
+// https://api.hypixel.net/#tag/Housing/paths/~1v2~1housing~1house/get
+func (c *Client) GetSpecificHouseInformation(house string) (*http.Response, error) {
+	return c.Send(http.MethodGet, c.Authentication(), "housing/house", &Params{
+		"house": house,
+	})
+}
+
+// GetSpecificPlayerPublicHouses The public houses for a specific player.//
+// This data may be cached for a short period of time.
+//
+// https://api.hypixel.net/#tag/Housing/paths/~1v2~1housing~1houses/get
+func (c *Client) GetSpecificPlayerPublicHouses(player string) (*http.Response, error) {
+	return c.Send(http.MethodGet, c.Authentication(), "housing/houses", &Params{
+		"player": player,
+	})
+}
+
+// GetActiveNetworkBoosters Active Network Boosters
+//
+// https://api.hypixel.net/#tag/Other/paths/~1v2~1boosters/get
+func (c *Client) GetActiveNetworkBoosters() (*http.Response, error) {
+	return c.Send(http.MethodGet, c.Authentication(), "boosters", nil)
+}
+
+// GetCurrentPlayerCounts Current Player Counts
+//
+// https://api.hypixel.net/#tag/Other/paths/~1v2~1counts/get
+func (c *Client) GetCurrentPlayerCounts() (*http.Response, error) {
+	return c.Send(http.MethodGet, c.Authentication(), "counts", nil)
+}
+
+// GetCurrentLeaderboards Current Leaderboards
+//
+// https://api.hypixel.net/#tag/Other/paths/~1v2~1leaderboards/get
+func (c *Client) GetCurrentLeaderboards() (*http.Response, error) {
+	return c.Send(http.MethodGet, c.Authentication(), "leaderboards", nil)
+}
+
+// GetPunishmentStatistics Punishment Statistics
+//
+// https://api.hypixel.net/#tag/Other/paths/~1v2~1punishmentstats/get
+func (c *Client) GetPunishmentStatistics() (*http.Response, error) {
+	return c.Send(http.MethodGet, c.Authentication(), "punishmentstats", nil)
 }

--- a/api_test.go
+++ b/api_test.go
@@ -7,7 +7,12 @@ import (
 
 func TestClient_Authentication(t *testing.T) {
 	h := http.Header{}
-	if NewClient("test1", nil).AuthHeader(h).Get("API-Key") != "test1" {
+	h.Set("head", "value1")
+	c := NewClient("test1", nil)
+	if c.AuthHeader(h).Get("API-Key") != "test1" {
 		t.Errorf("expected 'test1', got %s", h.Get("API-Key"))
+	}
+	if h.Get("head") != "value1" {
+		t.Errorf("expected 'value1', got %s", h.Get("head"))
 	}
 }

--- a/api_test.go
+++ b/api_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestClient_Authentication(t *testing.T) {
 	h := http.Header{}
-	if NewClient("test1", nil).Authentication(h).Get("API-Key") != "test1" {
+	if NewClient("test1", nil).AuthHeader(h).Get("API-Key") != "test1" {
 		t.Errorf("expected 'test1', got %s", h.Get("API-Key"))
 	}
 }

--- a/client.go
+++ b/client.go
@@ -6,10 +6,10 @@ import (
 )
 
 type Client struct {
-	BaseURL string
-	APIKey  string
-	HTTP    *http.Client
-	Rate    *RateLimit
+	baseURL    string
+	apiKey     string
+	httpClient *http.Client
+	rate       *RateLimit
 }
 
 // NewClient creates a new hypixel client
@@ -18,37 +18,45 @@ type Client struct {
 // https://api.hypixel.net/
 func NewClient(key string, rate *RateLimit) *Client {
 	return &Client{
-		BaseURL: "https://api.hypixel.net/v2/",
-		APIKey:  key,
-		HTTP:    http.DefaultClient,
-		Rate:    rate,
+		baseURL:    "https://api.hypixel.net/v2/",
+		apiKey:     key,
+		httpClient: http.DefaultClient,
+		rate:       rate,
 	}
 }
 
 func (c *Client) GetBaseURL() string {
-	return c.BaseURL
+	return c.baseURL
 }
 
 func (c *Client) GetAPIKey() string {
-	return c.APIKey
+	return c.apiKey
 }
 
 func (c *Client) GetHTTPClient() *http.Client {
-	return c.HTTP
+	return c.httpClient
 }
 
-func (c *Client) SetBaseURL(url string) {
-	c.BaseURL = url
-}
-
-func (c *Client) SetHTTPClient(client *http.Client) {
-	c.HTTP = client
-}
-
-func (c *Client) SetAPIKey(key string) {
-	c.APIKey = key
+func (c *Client) GetRate() *RateLimit {
+	return c.rate
 }
 
 func (c *Client) GetFullPath(path string) string {
-	return strings.TrimRight(c.BaseURL, "/") + "/" + strings.TrimLeft(path, "/")
+	return strings.TrimRight(c.baseURL, "/") + "/" + strings.TrimLeft(path, "/")
+}
+
+func (c *Client) SetBaseURL(url string) {
+	c.baseURL = url
+}
+
+func (c *Client) SetHTTPClient(client *http.Client) {
+	c.httpClient = client
+}
+
+func (c *Client) SetAPIKey(key string) {
+	c.apiKey = key
+}
+
+func (c *Client) SetRate(rate *RateLimit) {
+	c.rate = rate
 }

--- a/client_test.go
+++ b/client_test.go
@@ -11,30 +11,30 @@ func TestNewClient(t *testing.T) {
 
 	client := NewClient(apiKey, rateLimit)
 
-	if client.APIKey != apiKey {
-		t.Errorf("Expected API key %s, got %s", apiKey, client.APIKey)
+	if client.apiKey != apiKey {
+		t.Errorf("Expected API key %s, got %s", apiKey, client.apiKey)
 	}
 
-	if client.BaseURL != "https://api.hypixel.net/v2/" {
-		t.Errorf("Expected base URL %s, got %s", "https://api.hypixel.net/v2/", client.BaseURL)
+	if client.baseURL != "https://api.hypixel.net/v2/" {
+		t.Errorf("Expected base URL %s, got %s", "https://api.hypixel.net/v2/", client.baseURL)
 	}
 
-	if client.HTTP != http.DefaultClient {
+	if client.httpClient != http.DefaultClient {
 		t.Error("Expected default HTTP client")
 	}
 
-	if client.Rate != rateLimit {
-		t.Error("Rate limit not set correctly")
+	if client.rate != rateLimit {
+		t.Error("rate limit not set correctly")
 	}
 }
 
 func TestGetters(t *testing.T) {
 	customHTTP := &http.Client{}
 	client := &Client{
-		BaseURL: "https://custom.url/",
-		APIKey:  "custom-key",
-		HTTP:    customHTTP,
-		Rate:    &RateLimit{},
+		baseURL:    "https://custom.url/",
+		apiKey:     "custom-key",
+		httpClient: customHTTP,
+		rate:       &RateLimit{},
 	}
 
 	t.Run("GetBaseURL", func(t *testing.T) {
@@ -62,24 +62,24 @@ func TestSetters(t *testing.T) {
 	t.Run("SetBaseURL", func(t *testing.T) {
 		newURL := "https://new.url/"
 		client.SetBaseURL(newURL)
-		if client.BaseURL != newURL {
-			t.Errorf("SetBaseURL() failed, got %v, want %v", client.BaseURL, newURL)
+		if client.baseURL != newURL {
+			t.Errorf("SetBaseURL() failed, got %v, want %v", client.baseURL, newURL)
 		}
 	})
 
 	t.Run("SetAPIKey", func(t *testing.T) {
 		newKey := "new-key"
 		client.SetAPIKey(newKey)
-		if client.APIKey != newKey {
-			t.Errorf("SetAPIKey() failed, got %v, want %v", client.APIKey, newKey)
+		if client.apiKey != newKey {
+			t.Errorf("SetAPIKey() failed, got %v, want %v", client.apiKey, newKey)
 		}
 	})
 
 	t.Run("SetHTTPClient", func(t *testing.T) {
 		newClient := &http.Client{}
 		client.SetHTTPClient(newClient)
-		if client.HTTP != newClient {
-			t.Errorf("SetHTTPClient() failed, got %v, want %v", client.HTTP, newClient)
+		if client.httpClient != newClient {
+			t.Errorf("SetHTTPClient() failed, got %v, want %v", client.httpClient, newClient)
 		}
 	})
 }
@@ -119,7 +119,7 @@ func TestGetFullPath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client := &Client{BaseURL: tt.baseURL}
+			client := &Client{baseURL: tt.baseURL}
 			result := client.GetFullPath(tt.path)
 			if result != tt.expected {
 				t.Errorf("GetFullPath() = %v, want %v", result, tt.expected)


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

将客户端配置字段私有化，重构请求逻辑，添加全面的 Hypixel API v2 端点包装器，更新测试以适应新的客户端接口，并刷新 README 徽章和许可证信息。

新功能：
- 引入核心资源端点的包装方法（游戏信息、成就、挑战、任务、公会成就、装饰宠物、装饰伙伴）。
- 添加 SkyBlock API 方法，用于集合、技能、物品、选举与市长、当前宾果活动、新闻、拍卖（单个、活跃、结束）、集市、个人资料、博物馆、花园、宾果数据和促销活动。
- 添加 Housing API 方法，用于活跃的公共房屋、特定房屋的详细信息以及玩家的公共房屋。
- 添加其他 API 方法，用于活跃的网络加速器、当前玩家数量、当前排行榜和惩罚统计信息。

增强功能：
- 将 Client 结构字段转换为未导出字段（baseURL、apiKey、httpClient、rate），并更新相应的 getter、setter 和完整路径构建器。
- 重构 Send 以一致地使用 httpClient 和私有速率限制器字段来执行请求和处理速率。

文档：
- 使用其他 CI 徽章、项目描述和许可证部分刷新 README。

测试：
- 更新客户端测试以引用新的未导出字段和方法。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Privatize client configuration fields, refactor request logic, add comprehensive Hypixel API v2 endpoint wrappers, update tests for the new client interface, and refresh README badges and license info.

New Features:
- Introduce wrapper methods for core resource endpoints (games information, achievements, challenges, quests, guild achievements, vanity pets, vanity companions).
- Add SkyBlock API methods for collections, skills, items, election & mayor, current bingo events, news, auctions (single, active, ended), bazaar, profiles, museum, garden, bingo data, and firesales.
- Add housing API methods for active public houses, specific house details, and a player’s public houses.
- Add miscellaneous API methods for active network boosters, current player counts, current leaderboards, and punishment statistics.

Enhancements:
- Convert Client struct fields to unexported (baseURL, apiKey, httpClient, rate) and update corresponding getters, setters, and full-path builder.
- Refactor Send to consistently use the httpClient and private rate limiter field for request execution and rate handling.

Documentation:
- Refresh README with additional CI badges, project description, and license section.

Tests:
- Update client tests to reference the new unexported fields and methods.

</details>