### PR TITLE
v1.0.2

### DIFF
--- a/api.go
+++ b/api.go
@@ -60,7 +60,7 @@ func (c *Client) Get(r Request) (Response, error) {
 	}
 	defer rsp.Body.Close()
 	if c.GetRate() != nil {
-		_ = c.rate.UpdateFromHeaders(rsp.Header)
+		_ = c.GetRate().UpdateFromHeaders(rsp.Header)
 	}
 	content, err := io.ReadAll(rsp.Body)
 	if err != nil {

--- a/api.go
+++ b/api.go
@@ -66,8 +66,8 @@ func (c *Client) Get(r Request) (Response, error) {
 	if err != nil {
 		return Response{}, err
 	}
-	if c.GetCallBack() == nil {
-		response, err := c.GetCallBack()(r, Response{Path: full, Status: rsp.StatusCode, Content: content}, err)
+	if c.GetCallback() == nil {
+		response, err := c.GetCallback()(r, Response{Path: full, Status: rsp.StatusCode, Content: content}, err)
 		if err == nil {
 			return response, nil
 		}

--- a/api.go
+++ b/api.go
@@ -66,9 +66,11 @@ func (c *Client) Get(r Request) (Response, error) {
 	if err != nil {
 		return Response{}, err
 	}
-	response, err := c.GetCallBack()(r, Response{Path: full, Status: rsp.StatusCode, Content: content}, err)
-	if err == nil {
-		return response, nil
+	if c.GetCallBack() == nil {
+		response, err := c.GetCallBack()(r, Response{Path: full, Status: rsp.StatusCode, Content: content}, err)
+		if err == nil {
+			return response, nil
+		}
 	}
 	return Response{Path: full, Status: rsp.StatusCode, Content: content}, nil
 }
@@ -137,21 +139,15 @@ func (c *Client) GetStatus(uuid string) (Response, error) {
 //
 // https://api.hypixel.net/#tag/Player-Data/paths/~1v2~1guild/get
 func (c *Client) GetGuild(id, player, name string) (Response, error) {
-	params := Params{}
-	if id != "" {
-		params["id"] = id
-	}
-	if player != "" {
-		params["player"] = player
-	}
-	if name != "" {
-		params["name"] = name
-	}
 	return c.Get(Request{
 		Method: http.MethodGet,
 		Header: c.AuthHeader(),
 		Path:   "guild",
-		Params: &params,
+		Params: &Params{
+			"id":     id,
+			"player": player,
+			"name":   name,
+		},
 	})
 }
 

--- a/api.go
+++ b/api.go
@@ -2,7 +2,6 @@ package hypixel
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"net/http"
 )
@@ -309,7 +308,7 @@ func (c *Client) GetSkyBlockNews() (Response, error) {
 	return c.Get(Request{
 		Method: http.MethodGet,
 		Header: c.AuthHeader(),
-		Path:   "skyblock/news", // Corrected path based on common API patterns, original might be /v2/skyblock/news
+		Path:   "skyblock/news",
 		Params: nil,
 	})
 }
@@ -339,10 +338,10 @@ func (c *Client) GetAuctions(uuid, player, profile string) (Response, error) {
 func (c *Client) GetActiveAuctions(page uint) (Response, error) {
 	return c.Get(Request{
 		Method: http.MethodGet,
-		Header: nil, // API docs for this specific endpoint don't explicitly state API key needed, but often they are for paginated resources. Assuming none for now.
+		Header: nil,
 		Path:   "skyblock/auctions",
 		Params: &Params{
-			"page": fmt.Sprintf("%d", page), // Convert uint to string for query parameter
+			"page": page,
 		},
 	})
 }

--- a/api.go
+++ b/api.go
@@ -324,24 +324,15 @@ func (c *Client) GetSkyBlockNews() (Response, error) {
 //
 // https://api.hypixel.net/#tag/SkyBlock/paths/~1v2~1skyblock~1auction/get
 func (c *Client) GetAuctions(uuid, player, profile string) (Response, error) {
-	params := Params{}
-	// API states only one query parameter can be used.
-	// This implementation will add whichever is non-empty,
-	// prioritizing uuid, then player, then profile if multiple are provided.
-	// A more robust implementation might return an error if more than one is set.
-	if uuid != "" {
-		params["uuid"] = uuid
-	} else if player != "" {
-		params["player"] = player
-	} else if profile != "" {
-		params["profile"] = profile
-	}
-
 	return c.Get(Request{
 		Method: http.MethodGet,
 		Header: c.AuthHeader(),
 		Path:   "skyblock/auction",
-		Params: &params,
+		Params: &Params{
+			"uuid":    uuid,
+			"player":  player,
+			"profile": profile,
+		},
 	})
 }
 
@@ -389,6 +380,8 @@ func (c *Client) GetRecentlyEndedAuctions() (Response, error) {
 // sellPrice and are the weighted average of the top 2% of orders by volume.buyPrice
 // movingWeek is the historic transacted volume from last 7d + live state.
 // sellOrders and are the count of active orders. buyOrders
+//
+// https://api.hypixel.net/#tag/SkyBlock/paths/~1v2~1skyblock~1bazaar/get
 func (c *Client) GetBazaar() (Response, error) {
 	return c.Get(Request{
 		Method: http.MethodGet,
@@ -466,13 +459,11 @@ func (c *Client) GetGardenData(profile string) (Response, error) {
 // NEED API Key
 //
 // https://api.hypixel.net/#tag/SkyBlock/paths/~1v2~1skyblock~1bingo/get
-// Note: Path conflicts with GetSkyBlockCurrentBingoEvent if both use "skyblock/bingo". The API doc link here is to /v2/skyblock/bingo.
-// This GET request to /v2/skyblock/bingo requires a `uuid` param for player data.
 func (c *Client) GetBingoData(uuid string) (Response, error) {
 	return c.Get(Request{
 		Method: http.MethodGet,
 		Header: c.AuthHeader(),
-		Path:   "skyblock/bingo", // Assuming this path is correct for player-specific bingo data when uuid is provided.
+		Path:   "skyblock/bingo",
 		Params: &Params{
 			"uuid": uuid,
 		},

--- a/api.go
+++ b/api.go
@@ -68,7 +68,7 @@ func (c *Client) Get(r Request) (Response, error) {
 		return Response{}, err
 	}
 	resp := Response{Path: r.Path, URL: r.URL, Status: rsp.StatusCode, Content: content}
-	if c.GetCallback() == nil {
+	if c.GetCallback() != nil {
 		response, err := c.GetCallback()(r, resp, err)
 		if err == nil {
 			return response, nil

--- a/api.go
+++ b/api.go
@@ -67,7 +67,7 @@ func (c *Client) Get(r Request) (Response, error) {
 	if err != nil {
 		return Response{}, err
 	}
-	resp := Response{Path: r.Path, URL: r.URL, Status: rsp.StatusCode, Content: content}
+	resp := Response{Header: rsp.Header, Path: r.Path, URL: r.URL, Status: rsp.StatusCode, Content: content}
 	if c.GetCallback() != nil {
 		response, err := c.GetCallback()(r, resp, err)
 		if err == nil {

--- a/client.go
+++ b/client.go
@@ -6,7 +6,7 @@ import (
 )
 
 type PreRequestHook func(request Request) (Response, error)
-type CallBack func(request Request, response Response, err error) (Response, error)
+type Callback func(request Request, response Response, err error) (Response, error)
 
 type Client struct {
 	baseURL        string
@@ -14,7 +14,7 @@ type Client struct {
 	httpClient     *http.Client
 	rate           *RateLimit
 	preRequestHook PreRequestHook
-	callBack       CallBack
+	callBack       Callback
 }
 
 // NewClient creates a new hypixel client
@@ -50,7 +50,7 @@ func (c *Client) GetPreRequestHook() PreRequestHook {
 	return c.preRequestHook
 }
 
-func (c *Client) GetCallBack() CallBack {
+func (c *Client) GetCallback() Callback {
 	return c.callBack
 }
 
@@ -78,6 +78,6 @@ func (c *Client) SetPreRequestHook(beforeSend PreRequestHook) {
 	c.preRequestHook = beforeSend
 }
 
-func (c *Client) SetCallBack(callBack CallBack) {
+func (c *Client) SetCallback(callBack Callback) {
 	c.callBack = callBack
 }

--- a/client.go
+++ b/client.go
@@ -55,7 +55,7 @@ func (c *Client) GetCallBack() CallBack {
 }
 
 func (c *Client) GetFullPath(path string) string {
-	return strings.TrimRight(c.baseURL, "/") + "/" + strings.TrimLeft(path, "/")
+	return strings.TrimRight(c.GetBaseURL(), "/") + "/" + strings.TrimLeft(path, "/")
 }
 
 func (c *Client) SetBaseURL(url string) {

--- a/client.go
+++ b/client.go
@@ -5,11 +5,16 @@ import (
 	"strings"
 )
 
+type PreRequestHook func(request Request) (Response, error)
+type CallBack func(request Request, response Response, err error) (Response, error)
+
 type Client struct {
-	baseURL    string
-	apiKey     string
-	httpClient *http.Client
-	rate       *RateLimit
+	baseURL        string
+	apiKey         string
+	httpClient     *http.Client
+	rate           *RateLimit
+	preRequestHook PreRequestHook
+	callBack       CallBack
 }
 
 // NewClient creates a new hypixel client
@@ -41,6 +46,14 @@ func (c *Client) GetRate() *RateLimit {
 	return c.rate
 }
 
+func (c *Client) GetPreRequestHook() PreRequestHook {
+	return c.preRequestHook
+}
+
+func (c *Client) GetCallBack() CallBack {
+	return c.callBack
+}
+
 func (c *Client) GetFullPath(path string) string {
 	return strings.TrimRight(c.baseURL, "/") + "/" + strings.TrimLeft(path, "/")
 }
@@ -59,4 +72,12 @@ func (c *Client) SetAPIKey(key string) {
 
 func (c *Client) SetRate(rate *RateLimit) {
 	c.rate = rate
+}
+
+func (c *Client) SetPreRequestHook(beforeSend PreRequestHook) {
+	c.preRequestHook = beforeSend
+}
+
+func (c *Client) SetCallBack(callBack CallBack) {
+	c.callBack = callBack
 }


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

重构 Hypixel API 客户端，使用统一的 Request/Response 模型，并为请求和响应处理添加可自定义的钩子。

增强功能：
- 引入 Request 和 Response 类型来替换旧的 Send 方法。
- 实现一个新的 Client.Get 方法，支持 pre-request 钩子和回调。
- 重构所有现有的 endpoint 方法，以使用新的 Request/Response 模式。
- 为 pre-request 钩子和 response 回调添加 getter 和 setter。
- 在统一的流程中标准化路径构建、header 分配、速率限制和响应解析。

<details>
<summary>Original summary in English</summary>

好的，这是将给定的 pull request 总结翻译成中文的结果：

## Sourcery 总结

通过用新的 `Client.Get` 方法替换旧的 `Send` 方法来实现统一的 Request/Response 模型，添加可自定义的 pre-request 钩子和 response 回调，并重构所有端点函数以集成新的模式，包括标准化路径构建、header 分配、速率限制和 response 解析。

新特性：
- 引入 Request 和 Response 类型来表示 HTTP 请求和响应数据
- 实现 `Client.Get` 方法，支持 pre-request 钩子和 response 回调
- 在 Client 上添加 pre-request 钩子和回调的 getter 和 setter

增强功能：
- 重构所有 API 端点方法以使用新的 Request/Response 模式
- 标准化跨请求的路径构建、header 注入、速率限制和 response 解析
- 替换内部 `Send` 方法并更新 HTTP 客户端和速率限制访问器

<details>
<summary>Original summary in English</summary>

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

重构 Hypixel API 客户端，使用结构化的请求/响应模型，支持预请求钩子和响应回调

增强功能：
- 引入 Request 和 Response 类型，并用统一的 Get 方法替换旧的 Send 方法
- 添加 PreRequestHook 和 Callback，以允许自定义预请求处理和响应处理
- 重构所有现有的端点方法，以使用新的 Request/Response 模型
- 在单个流程中标准化 URL 构建、标头分配、速率限制和响应解析

<details>
<summary>Original summary in English</summary>

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

统一 HTTP 交互方式，用结构化的 Get API 替换旧的 Send 方法。新的 Get API 使用新的 Request 和 Response 类型，支持自定义的 pre-request 钩子和 response 回调，并将所有端点重构为使用新的模型。

增强功能：
- 引入 Request 和 Response 类型，并用统一的 Client.Get 方法替换 Client.Send
- 增加 PreRequestHook 和 Callback 支持，并提供相应的 getter 和 setter
- 在新的请求流程中，标准化 URL 构建、header 注入、速率限制和 response 解析
- 重构所有现有的端点方法，以使用新的 Request/Response 模式并返回结构化的 Response

<details>
<summary>Original summary in English</summary>

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

重构 Hypixel API 客户端，通过新的 Get 方法使用结构化的 Request/Response 模型，添加可自定义的请求前钩子和响应回调，并将所有端点迁移到新的流程。

新特性：
- 引入 Request 和 Response 结构体，以结构化的模型表示 HTTP 调用。
- 添加 Client.Get 方法，支持可自定义的请求前钩子和响应回调。
- 实现 PreRequestHook 和 Callback 类型，以及它们在 Client 上的 getter 和 setter。

增强功能：
- 迁移所有端点方法，以使用新的 Request/Response 流程代替旧的 Send 方法。
- 标准化所有请求的 URL 构建、header 分配、速率限制和响应解析。

<details>
<summary>Original summary in English</summary>

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

重构 Hypixel API 客户端，采用结构化的请求/响应模型，使用统一的 `Client.Get` 方法和可自定义的钩子，并将所有现有端点迁移到这个新的工作流程，同时整合 URL 构建、header 管理、速率限制和响应解析。

新特性：
- 引入 `Request` 和 `Response` 类型来建模 HTTP 交互
- 添加 `Client.Get` 方法，替换旧的 `Send` 函数
- 支持通过 `PreRequestHook` 和 `Callback` 实现可自定义的请求前钩子和响应后回调

增强功能：
- 重构所有端点方法以使用新的请求/响应流程
- 标准化跨请求的 URL 构建、header 注入、速率限制处理和响应解析

<details>
<summary>Original summary in English</summary>

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

重构 Hypixel API 客户端，采用结构化的请求/响应模型和统一的 Get 方法，添加可自定义的请求前钩子和响应回调，并将所有端点迁移到新的工作流程。

新特性：
- 引入结构化的请求和响应类型，用于 HTTP 交互
- 添加 Client.Get 方法，支持可自定义的请求前钩子和响应回调
- 定义 PreRequestHook 和 Callback 类型，以及相应的 getter 和 setter

增强功能：
- 迁移所有现有的 API 端点方法，以使用新的请求/响应工作流程
- 标准化客户端中的 URL 构建、header 管理、速率限制和响应解析
- 使用统一的 Get 方法替换内部的 Send 方法，并相应地更新客户端内部结构

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the Hypixel API client to adopt a structured Request/Response model with a unified Get method, add customizable pre-request hooks and response callbacks, and migrate all endpoints to the new workflow.

New Features:
- Introduce structured Request and Response types for HTTP interactions
- Add Client.Get method with support for customizable pre-request hooks and response callbacks
- Define PreRequestHook and Callback types with corresponding getters and setters

Enhancements:
- Migrate all existing API endpoint methods to use the new Request/Response workflow
- Standardize URL construction, header management, rate limiting, and response parsing across the client
- Replace the internal Send method with the unified Get method and update client internals accordingly

</details>

</details>

</details>

</details>

</details>

</details>

</details>